### PR TITLE
Incrementing version number to 0.3.0

### DIFF
--- a/rvsearch/__init__.py
+++ b/rvsearch/__init__.py
@@ -7,6 +7,6 @@ from .search import *
 from .plots import *
 from .inject import *
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 DATADIR = os.path.join(sys.prefix, 'rvsearch_example_data')


### PR DESCRIPTION
 - Set option for linearized gamma offset fit. If nonlinear, and HIRES-j and k datasets present, imposing a gaussian prior on the offset between the two, with a mean of 0 and a standard deviation of 1.
 - Can now include stellar mass in the search object, to produce derived parameters and overplot mass/au of found planets on injection/recovery plots.