### PR TITLE
Hotfix for trend flag

### DIFF
--- a/rvsearch/__init__.py
+++ b/rvsearch/__init__.py
@@ -7,6 +7,6 @@ from .search import *
 from .plots import *
 from .inject import *
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 DATADIR = os.path.join(sys.prefix, 'rvsearch_example_data')

--- a/rvsearch/cli.py
+++ b/rvsearch/cli.py
@@ -67,7 +67,7 @@ def main():
     psr_search.add_argument('--trend',
                           action='store',
                           help="Trend free during periodogram calculation [default=False]",
-                          default=False, type=bool
+                          default=0, type=int
                           )
     psr_search.add_argument('--mcmc', action='store_true',
                           help="Run MCMC after search [default=False]"
@@ -141,8 +141,12 @@ def main():
 
     args = psr.parse_args()
 
-    args.func(args)
+    if args.trend not in [0, 1]:
+        raise Exception("Trend flag must be 0 or 1")
+    else:
+        args.trend = bool(args.trend)
 
+    args.func(args)
 
 if __name__ == '__main__':
     main()

--- a/rvsearch/driver.py
+++ b/rvsearch/driver.py
@@ -41,8 +41,10 @@ def run_search(args):
 
     if args.known and P.nplanets > 0:
         ipost = copy.deepcopy(post)
-        post = radvel.fitting.maxlike_fitting(post, verbose=True)
         post.params['dvdt'].vary = args.trend
+        if not args.trend:
+            post.params['dvdt'].value = 0.0
+        post = radvel.fitting.maxlike_fitting(post, verbose=True)
     else:
         post = None
 


### PR DESCRIPTION
- increment to v0.3.1
- changed `--trend` flag to int with a value check because bool wasn't working. It was interpreting any input for that flag as "True"
- disable trend fitting in pre-search MAP fit and set the trend to 0 if `--trend=0`